### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,91 +91,91 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Bring Developer](http://developer.bring.com)                                                             | JSON/XML/SOAP | Public |
-| [CoolRunner](https://docs.coolrunner.dk)                                                                  | JSON | Private |
-| [GLS Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)                                   | SOAP | Public |
-| [GLS Parcel Processing](http://api.gls.dk/ws/)                                                            | JSON/XML | Private |
-| [Pakkelabels.dk](https://api.pakkelabels.dk)                                                              | JSON | Private |
-| [PostNord Developer](https://developer.postnord.com)                                                      | JSON | Private |
-| [UPS](https://www.ups.com/upsdeveloperkit?loc=da_DK)                                                      | JSON/XML/Webservice | Private |
-| [Unifaun](https://www.unifaunonline.se/rs-docs/)                                                          | JSON | Private |
-| [Webshipr](http://docs.webshipr.apiary.io)                                                                | JSON | Private |
+| [Bring Developer](http://developer.bring.com)                                                                 | JSON/XML/SOAP | Public |
+| [CoolRunner](https://docs.coolrunner.dk)                                                                       | JSON | Private |
+| [GLS Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)                                        | SOAP | Public |
+| [GLS Parcel Processing](http://api.gls.dk/ws/)                                                                 | JSON/XML | Private |
+| [Pakkelabels.dk](https://api.pakkelabels.dk)                                                                   | JSON | Private |
+| [PostNord Developer](https://developer.postnord.com)                                                           | JSON | Private |
+| [UPS](https://www.ups.com/upsdeveloperkit?loc=da_DK)                                                   | JSON/XML/Webservice | Private |
+| [Unifaun](https://www.unifaunonline.se/rs-docs/)                                                               | JSON | Private |
+| [Webshipr](http://docs.webshipr.apiary.io)                                                                     | JSON | Private |
 
 
 ## Regnskabsprogrammer
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Billy](https://www.billy.dk/api)                                                                         | JSON | Private |
-| [Dinero](https://api.dinero.dk/docs)                                                                      | JSON | Private |
-| [e-conomic](https://restdocs.e-conomic.com)                                                               | JSON | Private |
-| [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                           | JSON | Private |
-| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                      | ? | Private |
-| [Visma](https://developer.vismaonline.com/)                                                               | JSON | Private |
+| [Billy](https://www.billy.dk/api)                                                                              | JSON | Private |
+| [Dinero](https://api.dinero.dk/docs)                                                                           | JSON | Private |
+| [e-conomic](https://restdocs.e-conomic.com)                                                                    | JSON | Private |
+| [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                                | JSON | Private |
+| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                           | ? | Private |
+| [Visma](https://developer.vismaonline.com/)                                                                    | JSON | Private |
 
 ## Reklamer
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [eTilbudsavis](http://docs.api.etilbudsavis.dk)                                                           | JSON | Private |
+| [eTilbudsavis](http://docs.api.etilbudsavis.dk)                                                                | JSON | Private |
 
 
 ## SMS Gateways
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Txty.dk](http://api.txty.dk/4/)                                                                          | JSON | Private |
-| [SMS1919.dk](http://www.sms1919.dk/api/)                                                                  | XML | Private |
-| [GatewayAPI.com](https://gatewayapi.com/docs/)                                                            | JSON/SOAP | Private |
+| [Txty.dk](http://api.txty.dk/4/)                                                                               | JSON | Private |
+| [SMS1919.dk](http://www.sms1919.dk/api/)                                                                       | XML | Private |
+| [GatewayAPI.com](https://gatewayapi.com/docs/)                                                                 | JSON/SOAP | Private |
 
 
 ## Statistisk
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Danmarks Statistik](http://www.dst.dk/da/Statistik/statistikbanken/api)                                  | JSON/XML | Public |
+| [Danmarks Statistik](http://www.dst.dk/da/Statistik/statistikbanken/api)                                       | JSON/XML | Public |
 
 
 ## Telefoni
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Firmafon](https://dev.firmafon.dk/)                                                                      | JSON | Private |
-| [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)                         | JSON/XML | Private |
+| [Firmafon](https://dev.firmafon.dk/)                                                                           | JSON | Private |
+| [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)                              | JSON/XML | Private |
 
 
 ## Transport
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)                                                            | RSS | Public |
-| [GoMore](http://developer.gomore.com/)                                                                    | JSON | Private |
-| [Rejseplanen Labs](https://help.rejseplanen.dk/hc/da/categories/201728005)                                | JSON/XML | Private |
+| [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)                                                                 | RSS | Public |
+| [GoMore](http://developer.gomore.com/)                                                                         | JSON | Private |
+| [Rejseplanen Labs](https://help.rejseplanen.dk/hc/da/categories/201728005)                                     | JSON/XML | Private |
 
 
 ## Virksomhedsdata
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [CVRAPI](http://cvrapi.dk)                                                                                | JSON | Public |
-| [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)          | JSON | Public |
-| [CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data).     | JSON | Public |
-| [eniro](https://api.eniro.com)                                                                            | JSON | Private |
+| [CVRAPI](http://cvrapi.dk)                                                                                     | JSON | Public |
+| [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)               | JSON | Public |
+| [CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data).          | JSON | Public |
+| [eniro](https://api.eniro.com)                                                                                 | JSON | Private |
 
 
 ## Diverse
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)  | XML | Public |
-| [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)                                                | XML | Public |
-| [Folketinget](http://www.ft.dk/AabneData)                                                                 | JSON/XML | Public |
-| [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)                  | XML | Public |
-| ~~[Lav Linket Kortere](http://llk.dk/api)~~                                                               | RAW/HTTP | Public |
-| [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)                                 | JSON | Public |
-| [Trustpilot](https://developers.trustpilot.com/)                                                          | JSON | Private |
-| [TimeLog](http://api.timelog.com/)                                                                        | XML | Public |
-| [Ordrestyring.dk](https://api.ordrestyring.dk/)                                                           | JSON | Private |
+| [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)       | XML | Public |
+| [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)                                                     | XML | Public |
+| [Folketinget](http://www.ft.dk/AabneData)                                                                      | JSON/XML | Public |
+| [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)                       | XML | Public |
+| ~~[Lav Linket Kortere](http://llk.dk/api)~~                                                                    | RAW/HTTP | Public |
+| [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)                                      | JSON | Public |
+| [Trustpilot](https://developers.trustpilot.com/)                                                               | JSON | Private |
+| [TimeLog](http://api.timelog.com/)                                                                             | XML | Public |
+| [Ordrestyring.dk](https://api.ordrestyring.dk/)                                                                | JSON | Private |
 
 
 ## Information

--- a/README.md
+++ b/README.md
@@ -3,176 +3,189 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 ## Betalingsløsninger
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Clearhaus](http://docs.gateway.clearhaus.com/)                                                           | JSON | ✅ | ❌ |
-| [ePay](http://tech.epay.dk/da/betalingswebservice)                                                        | JSON | ✅ | ❌ |
-| [MobilePay](https://www.mobilepay.dk/da-dk/Developer/Pages/developer.aspx)                                | JSON | ✅❌ | ✅ |
-| [Paylike](https://github.com/paylike/api-docs)                                                            | JSON | ✅ | ❌ |
-| [QuickPay](https://quickpay.net/quickpayapi)                                                              | JSON | ✅ | ❌ |
-| [YourPay](http://api.yourpay.dk)                                                                          | JSON | ✅ | ❌ |
-| [Wannafind](https://static.zitcom.dk/marketing/wannafind/paymentgateway_documentation.pdf)                | HTML/Form | ✅ | ❌ |
-| [DIBS](http://tech.dibspayment.com/D2/API)                                                                | JSON | ✅ | ❌ |
-| [Reepay](https://docs.reepay.com/api/)                                                                    | JSON | ✅ | ❌ |
-| [AltaPay](https://altapay.com/technology/integration-manuals#download)                                    | JSON | ✅ | ❌ |
-| [Scanpay](https://docs.scanpay.dk)                                                                        | JSON | ✅ | ❌ |
-| [Nets Netaxept](https://shop.nets.eu/da/web/partners)                                                     | XML | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Clearhaus](http://docs.gateway.clearhaus.com/)                                                                | JSON | Private |
+| [ePay](http://tech.epay.dk/da/betalingswebservice)                                                             | JSON | Private |
+| [MobilePay](https://www.mobilepay.dk/da-dk/Developer/Pages/developer.aspx)                                     | JSON | Public |
+| [Paylike](https://github.com/paylike/api-docs)                                                                 | JSON | Private |
+| [QuickPay](https://quickpay.net/quickpayapi)                                                                   | JSON | Private |
+| [YourPay](http://api.yourpay.dk)                                                                               | JSON | Private |
+| [Wannafind](https://static.zitcom.dk/marketing/wannafind/paymentgateway_documentation.pdf)                     | HTML/Form | Private |
+| [DIBS](http://tech.dibspayment.com/D2/API)                                                                     | JSON | Private |
+| [Reepay](https://docs.reepay.com/api/)                                                                         | JSON | Private |
+| [AltaPay](https://altapay.com/technology/integration-manuals#download)                                         | JSON | Private |
+| [Scanpay](https://docs.scanpay.dk)                                                                             | JSON | Private |
+| [Nets Netaxept](https://shop.nets.eu/da/web/partners)                                                          | XML | Private |
 
 
 ## Detail & webshops
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Dansk Supermarked](https://developer.dansksupermarked.dk/v1/api/reference/overview/)                     | JSON | ✅ | ❌ |
-| [SAXO.com](http://api.saxo.com/)                                                                          | XML | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Dansk Supermarked](https://developer.dansksupermarked.dk/v1/api/reference/overview/)                          | JSON | Private |
+| [SAXO.com](http://api.saxo.com/)                                                                               | XML | Private |
 
 
 ## Historie
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Dansk Kultur Arv](http://www.danskkulturarv.dk/api/)                                                     | XML | ✅ | ❌ |
-| [Historisk Atlas](http://api.historiskatlas.dk/)                                                          | JSON | ✅ | ✅ |
-| ~~[M/S Museet for Søfart](http://mfs.dk/soeg-i-soefartshistorien/api)~~                                   | JSON | ? | ? |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Dansk Kultur Arv](http://www.danskkulturarv.dk/api/)                                                          | XML | Private |
+| [Historisk Atlas](http://api.historiskatlas.dk/)                                                               | JSON | Public |
+| ~~[M/S Museet for Søfart](http://mfs.dk/soeg-i-soefartshistorien/api)~~                                        | JSON | ? |
 
 
 ## Hosting
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [HostedShop](http://api-help.hostedshop.dk) (Wannafind & ScanNet)                                         | SOAP | ✅ | ❌ |
-| [UnoEuro](https://www.unoeuro.com/docs/api.php)                                                           | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [HostedShop](http://api-help.hostedshop.dk) (Wannafind & ScanNet)                                              | SOAP | Private |
+| [UnoEuro](https://www.unoeuro.com/docs/api.php)                                                                | JSON | Private |
 
 
 ## Inkasso
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Debito](https://www.debito.dk/api)                                                                       | ? | ? | ? |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Debito](https://www.debito.dk/api)                                                                            | ? | ? |
 
 ## Medier
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [DR](http://www.dr.dk/mu-online/)                                                                         | JSON | ✅ | ✅ |
-| [TV2 Vejret API](https://vejret-api.tv2.dk) (Private API)                                                 | JSON/XML | ✅ | ❌ |
-| [Vejret i din by](http://vejr.eu/pages/api-documentation)                                                 | JSON | ✅ | ✅ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [DR](http://www.dr.dk/mu-online/)                                                                              | JSON | Public |
+| [TV2 Vejret API](https://vejret-api.tv2.dk) (Private API)                                                      | JSON/XML | Private |
+| [Vejret i din by](http://vejr.eu/pages/api-documentation)                                                      | JSON | Public |
 
 
 ## Miljødata
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Ressource](http://arealinformation.miljoeportal.dk/distribution/)                                        | ? | ? | ? |
-| ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~         | ? | ? | ? |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Ressource](http://arealinformation.miljoeportal.dk/distribution/)                                             | ? | ? |
+| ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~              | ? | ? |
 
 
 ## Offentlige
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Danmarks Adressers Web API - DAWA](https://dawa.aws.dk/)                                                 | JSON | ✅ | ✅ |
-| [Frekvenser](http://frekvens.erhvervsstyrelsen.dk/OffentligtAPI.pdf)                                      | JSON | ✅ | ✅ |
-| [Mastedatabasen](https://mastedatabasen.dk/Viskort/ContentPages/DataFraDatabasen.aspx?callingapp=mastedb#webapi) | JSON/XML/KML | ✅ | ✅ |
-| [Kortforsyningen](https://www.kortforsyningen.dk/content/webtjenester)                                    | JSON/XML | ✅ | ❌ |
-| [Liste over APIer udgivet af det offentlige](http://datahub.virk.dk/data/search)                          | HTML | ✅ | ✅ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Danmarks Adressers Web API - DAWA](https://dawa.aws.dk/)                                                      | JSON | Public |
+| [Frekvenser](http://frekvens.erhvervsstyrelsen.dk/OffentligtAPI.pdf)                                           | JSON | Public |
+| [Mastedatabasen](https://mastedatabasen.dk/Viskort/ContentPages/DataFraDatabasen.aspx?callingapp=mastedb#webapi) | JSON/XML/KML | Public |
+| [Kortforsyningen](https://www.kortforsyningen.dk/content/webtjenester)                                         | JSON/XML | Private |
+| [Liste over APIer udgivet af det offentlige](http://datahub.virk.dk/data/search)                               | HTML | Public |
 
 
 ### Åbne datasæt fra en række danske kommuner
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Københavns kommune data bank](http://data.kk.dk/)                                                        | Forskelligt | ✅ | ✅ |
-| [Københavns solutionlab](http://portal.opendata.dk)                                                       | Forskelligt | ✅ | ✅ |
-| [Åbne data fra Aarhus kommune](https://www.odaa.dk)                                                       | Forskelligt | ✅ | ✅ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Københavns kommune data bank](http://data.kk.dk/)                                                             | Forskelligt | Public |
+| [Københavns solutionlab](http://portal.opendata.dk)                                                            | Forskelligt | Public |
+| [Åbne data fra Aarhus kommune](https://www.odaa.dk)                                                            | Forskelligt | Public |
 
 
 ## Pakker & logistisk
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Bring Developer](http://developer.bring.com)                                                             | JSON/XML/SOAP | ✅ | ✅❌ |
-| [CoolRunner](https://docs.coolrunner.dk)                                                                  | JSON | ✅ | ❌ |
-| [GLS Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)                                   | SOAP | ✅ | ✅ |
-| [GLS Parcel Processing](http://api.gls.dk/ws/)                                                            | JSON/XML | ✅ | ❌ |
-| [Pakkelabels.dk](https://api.pakkelabels.dk)                                                              | JSON | ✅ | ❌ |
-| [PostNord Developer](https://developer.postnord.com)                                                      | JSON | ✅ | ❌ |
-| [UPS](https://www.ups.com/upsdeveloperkit?loc=da_DK)                                                      | JSON/XML/Webservice | ✅ | ❌ |
-| [Unifaun](https://www.unifaunonline.se/rs-docs/)                                                          | JSON | ✅ | ❌ |
-| [Webshipr](http://docs.webshipr.apiary.io)                                                                | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Bring Developer](http://developer.bring.com)                                                             | JSON/XML/SOAP | Public |
+| [CoolRunner](https://docs.coolrunner.dk)                                                                  | JSON | Private |
+| [GLS Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)                                   | SOAP | Public |
+| [GLS Parcel Processing](http://api.gls.dk/ws/)                                                            | JSON/XML | Private |
+| [Pakkelabels.dk](https://api.pakkelabels.dk)                                                              | JSON | Private |
+| [PostNord Developer](https://developer.postnord.com)                                                      | JSON | Private |
+| [UPS](https://www.ups.com/upsdeveloperkit?loc=da_DK)                                                      | JSON/XML/Webservice | Private |
+| [Unifaun](https://www.unifaunonline.se/rs-docs/)                                                          | JSON | Private |
+| [Webshipr](http://docs.webshipr.apiary.io)                                                                | JSON | Private |
 
 
 ## Regnskabsprogrammer
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Billy](https://www.billy.dk/api)                                                                         | JSON | ✅ | ❌ |
-| [Dinero](https://api.dinero.dk/docs)                                                                      | JSON | ✅ | ❌ |
-| [e-conomic](https://restdocs.e-conomic.com)                                                               | JSON | ✅ | ❌ |
-| [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                           | JSON | ✅ | ❌ |
-| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                      | ? | ✅ | ❌ |
-| [Visma](https://developer.vismaonline.com/)                                                               | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Billy](https://www.billy.dk/api)                                                                         | JSON | Private |
+| [Dinero](https://api.dinero.dk/docs)                                                                      | JSON | Private |
+| [e-conomic](https://restdocs.e-conomic.com)                                                               | JSON | Private |
+| [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                           | JSON | Private |
+| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                      | ? | Private |
+| [Visma](https://developer.vismaonline.com/)                                                               | JSON | Private |
 
 ## Reklamer
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [eTilbudsavis](http://docs.api.etilbudsavis.dk)                                                           | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [eTilbudsavis](http://docs.api.etilbudsavis.dk)                                                           | JSON | Private |
 
 
 ## SMS Gateways
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Txty.dk](http://api.txty.dk/4/)                                                                          | JSON | ✅ | ❌ |
-| [SMS1919.dk](http://www.sms1919.dk/api/)                                                                  | XML | ✅ | ❌ |
-| [GatewayAPI.com](https://gatewayapi.com/docs/)                                                            | JSON/SOAP | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Txty.dk](http://api.txty.dk/4/)                                                                          | JSON | Private |
+| [SMS1919.dk](http://www.sms1919.dk/api/)                                                                  | XML | Private |
+| [GatewayAPI.com](https://gatewayapi.com/docs/)                                                            | JSON/SOAP | Private |
 
 
 ## Statistisk
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Danmarks Statistik](http://www.dst.dk/da/Statistik/statistikbanken/api)                                  | JSON/XML | ✅ | ✅ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Danmarks Statistik](http://www.dst.dk/da/Statistik/statistikbanken/api)                                  | JSON/XML | Public |
 
 
 ## Telefoni
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Firmafon](https://dev.firmafon.dk/)                                                                      | JSON | ✅ | ❌ |
-| [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)                         | JSON/XML | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Firmafon](https://dev.firmafon.dk/)                                                                      | JSON | Private |
+| [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)                         | JSON/XML | Private |
 
 
 ## Transport
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)                                                            | RSS | ✅ | ✅ |
-| [GoMore](http://developer.gomore.com/)                                                                    | JSON | ✅ | ❌ |
-| [Rejseplanen Labs](https://help.rejseplanen.dk/hc/da/categories/201728005)                                | JSON/XML | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)                                                            | RSS | Public |
+| [GoMore](http://developer.gomore.com/)                                                                    | JSON | Private |
+| [Rejseplanen Labs](https://help.rejseplanen.dk/hc/da/categories/201728005)                                | JSON/XML | Private |
 
 
 ## Virksomhedsdata
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [CVRAPI](http://cvrapi.dk)                                                                                | JSON | ✅ | ✅ |
-| [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)          | JSON | ✅ | ✅ |
-| [CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data).     | JSON | ✅ | ✅ |
-| [eniro](https://api.eniro.com)                                                                            | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [CVRAPI](http://cvrapi.dk)                                                                                | JSON | Public |
+| [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)          | JSON | Public |
+| [CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data).     | JSON | Public |
+| [eniro](https://api.eniro.com)                                                                            | JSON | Private |
 
 
 ## Diverse
 
-| API                                                                                                       | Type | Gratis | Uden login |
-| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
-| [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)  | XML | ✅ | ✅ |
-| [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)                                                | XML | ✅ | ✅ |
-| [Folketinget](http://www.ft.dk/AabneData)                                                                 | JSON/XML | ✅ | ✅ |
-| [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)                  | XML | ✅ | ✅ |
-| ~~[Lav Linket Kortere](http://llk.dk/api)~~                                                               | RAW/HTTP | ✅ | ✅ |
-| [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)                                 | JSON | ✅ | ✅ |
-| [Trustpilot](https://developers.trustpilot.com/)                                                          | JSON | ✅ | ❌ |
-| [TimeLog](http://api.timelog.com/)                                                                        | XML | ✅ | ✅ |
-| [Ordrestyring.dk](https://api.ordrestyring.dk/)                                                           | JSON | ✅ | ❌ |
+| API                                                                                                            | Type | Tilgængelighed |
+| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
+| [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)  | XML | Public |
+| [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)                                                | XML | Public |
+| [Folketinget](http://www.ft.dk/AabneData)                                                                 | JSON/XML | Public |
+| [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)                  | XML | Public |
+| ~~[Lav Linket Kortere](http://llk.dk/api)~~                                                               | RAW/HTTP | Public |
+| [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)                                 | JSON | Public |
+| [Trustpilot](https://developers.trustpilot.com/)                                                          | JSON | Private |
+| [TimeLog](http://api.timelog.com/)                                                                        | XML | Public |
+| [Ordrestyring.dk](https://api.ordrestyring.dk/)                                                           | JSON | Private |
+
+
+## Information
+
+### Tilgængelighed
+
+#### Public
+
+Det er gratis at bruge API'et, også selvom det kræver login etc.
+
+#### Private
+
+Du skal have en "relation" til firmaet der udstiller API'et, betalt eller ej.

--- a/README.md
+++ b/README.md
@@ -145,15 +145,22 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 
 ## Transport
-- [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)
-- [GoMore](http://developer.gomore.com/)
-- [Rejseplanen Labs](http://labs.rejseplanen.dk/)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)                                                            | RSS | ✅ | ✅ |
+| [GoMore](http://developer.gomore.com/)                                                                    | JSON | ✅ | ❌ |
+| [Rejseplanen Labs](https://help.rejseplanen.dk/hc/da/categories/201728005)                                | JSON/XML | ✅ | ❌ |
+
 
 ## Virksomhedsdata
-- [CVRAPI](http://cvrapi.dk)
-- [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)
-- [eniro](https://api.eniro.com)
-- [System-til-system adgang til CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [CVRAPI](http://cvrapi.dk)                                                                                | JSON | ✅ | ✅ |
+| [Digitale regnskaber](http://datahub.virk.dk/dataset/system-til-system-adgang-til-regnskabsdata)          | JSON | ✅ | ✅ |
+| [CVR-data (Erhvervsstyrelsen)](http://datahub.virk.dk/dataset/system-til-system-adgang-til-cvr-data).     | JSON | ✅ | ✅ |
+| [eniro](https://api.eniro.com)                                                                            | JSON | ✅ | ❌ |
 
 
 ## Diverse

--- a/README.md
+++ b/README.md
@@ -2,69 +2,105 @@
 Kender du et dansk API der mangler på listen? Så send et pull request afsted eller opret en issue! 
 
 ## Betalingsløsninger
-- [Clearhaus](http://docs.gateway.clearhaus.com/)
-- [ePay](http://tech.epay.dk/da/betalingswebservice)
-- [MobilePay](https://www.mobilepay.dk/da-dk/Developer/Pages/developer.aspx)
-- [Paylike](https://github.com/paylike/api-docs)
-- [QuickPay](https://learn.quickpay.net/tech-talk/api)
-- [YourPay](http://api.yourpay.dk)
-- [Wannafind](https://static.zitcom.dk/marketing/wannafind/paymentgateway_documentation.pdf)
-- [DIBS](http://tech.dibspayment.com/D2/API)
-- [Reepay](https://docs.reepay.com/api/)
-- [AltaPay](https://altapay.com/technology/integration-manuals#download)
-- [Scanpay](https://docs.scanpay.dk)
-- [Nets Netaxept](https://shop.nets.eu/da/web/partners)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Clearhaus](http://docs.gateway.clearhaus.com/)                                                           | JSON | ✅ | ❌ |
+| [ePay](http://tech.epay.dk/da/betalingswebservice)                                                        | JSON | ✅ | ❌ |
+| [MobilePay](https://www.mobilepay.dk/da-dk/Developer/Pages/developer.aspx)                                | JSON | ✅❌ | ✅ |
+| [Paylike](https://github.com/paylike/api-docs)                                                            | JSON | ✅ | ❌ |
+| [QuickPay](https://quickpay.net/quickpayapi)                                                              | JSON | ✅ | ❌ |
+| [YourPay](http://api.yourpay.dk)                                                                          | JSON | ✅ | ❌ |
+| [Wannafind](https://static.zitcom.dk/marketing/wannafind/paymentgateway_documentation.pdf)                | HTML/Form | ✅ | ❌ |
+| [DIBS](http://tech.dibspayment.com/D2/API)                                                                | JSON | ✅ | ❌ |
+| [Reepay](https://docs.reepay.com/api/)                                                                    | JSON | ✅ | ❌ |
+| [AltaPay](https://altapay.com/technology/integration-manuals#download)                                    | JSON | ✅ | ❌ |
+| [Scanpay](https://docs.scanpay.dk)                                                                        | JSON | ✅ | ❌ |
+| [Nets Netaxept](https://shop.nets.eu/da/web/partners)                                                     | XML | ✅ | ❌ |
+
 
 ## Detail & webshops
-- [Dansk Supermarked](https://developer.dansksupermarked.dk/v1/api/reference/overview/)
-- [SAXO.com](http://api.saxo.com/)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Dansk Supermarked](https://developer.dansksupermarked.dk/v1/api/reference/overview/)                     | JSON | ✅ | ❌ |
+| [SAXO.com](http://api.saxo.com/)                                                                          | XML | ✅ | ❌ |
 
 
 ## Historie
-- [Dansk Kultur Arv](http://www.danskkulturarv.dk/api/)
-- [Historisk Atlas](http://blog.historiskatlas.dk/api/)
-- ~~[M/S Museet for Søfart](http://mfs.dk/soeg-i-soefartshistorien/api)~~
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Dansk Kultur Arv](http://www.danskkulturarv.dk/api/)                                                     | XML | ✅ | ❌ |
+| [Historisk Atlas](http://api.historiskatlas.dk/)                                                          | JSON | ✅ | ✅ |
+| ~~[M/S Museet for Søfart](http://mfs.dk/soeg-i-soefartshistorien/api)~~                                   | JSON | ? | ? |
+
 
 ## Hosting
-- [HostedShop](http://api-help.hostedshop.dk) (Wannafind & ScanNet)
-- [UnoEuro](https://www.unoeuro.com/docs/api.php)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [HostedShop](http://api-help.hostedshop.dk) (Wannafind & ScanNet)                                         | SOAP | ✅ | ❌ |
+| [UnoEuro](https://www.unoeuro.com/docs/api.php)                                                           | JSON | ✅ | ❌ |
+
 
 ## Inkasso
-- [Debito](https://www.debito.dk/api)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Debito](https://www.debito.dk/api)                                                                       | ? | ? | ? |
 
 ## Medier
-- [DR](http://www.dr.dk/mu-online/)
-- [TV2 Vejret API](https://vejret-api.tv2.dk) (Private API)
-- [Vejret i din by](http://vejr.eu/pages/api-documentation)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [DR](http://www.dr.dk/mu-online/)                                                                         | JSON | ✅ | ✅ |
+| [TV2 Vejret API](https://vejret-api.tv2.dk) (Private API)                                                 | JSON/XML | ✅ | ❌ |
+| [Vejret i din by](http://vejr.eu/pages/api-documentation)                                                 | JSON | ✅ | ✅ |
+
 
 ## Miljødata
-- Danmarks miljøportal kortviewer, her kan du se hvilke data, der er tilgængelige.
-    - [Ressource](http://arealinformation.miljoeportal.dk/distribution/)
-    - ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Ressource](http://arealinformation.miljoeportal.dk/distribution/)                                        | ? | ? | ? |
+| ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~         | ? | ? | ? |
+
 
 ## Offentlige
-- [Danmarks Adressers Web API - DAWA](https://dawa.aws.dk/)
-- [Frekvenser](http://frekvens.erhvervsstyrelsen.dk/OffentligtAPI.pdf)
-- [Kortforsyningen](https://www.kortforsyningen.dk/content/webtjenester)
-- [Mastedatabasen](https://mastedatabasen.dk/Viskort/ContentPages/DataFraDatabasen.aspx?callingapp=mastedb#webapi)
-- [Liste over APIer udgivet af det offentlige](http://datahub.virk.dk/data/search)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Danmarks Adressers Web API - DAWA](https://dawa.aws.dk/)                                                 | JSON | ✅ | ✅ |
+| [Frekvenser](http://frekvens.erhvervsstyrelsen.dk/OffentligtAPI.pdf)                                      | JSON | ✅ | ✅ |
+| [Mastedatabasen](https://mastedatabasen.dk/Viskort/ContentPages/DataFraDatabasen.aspx?callingapp=mastedb#webapi) | JSON/XML/KML | ✅ | ✅ |
+| [Kortforsyningen](https://www.kortforsyningen.dk/content/webtjenester)                                    | JSON/XML | ✅ | ❌ |
+| [Liste over APIer udgivet af det offentlige](http://datahub.virk.dk/data/search)                          | HTML | ✅ | ✅ |
+
 
 ### Åbne datasæt fra en række danske kommuner
-- [Københavns kommune data bank](http://data.kk.dk/)
-- [Københavns solutionlab](http://cphsolutionslab.dk/)
-- [Åbne data fra Aarhus kommune](https://www.odaa.dk)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Københavns kommune data bank](http://data.kk.dk/)                                                        | Forskelligt | ✅ | ✅ |
+| [Københavns solutionlab](http://portal.opendata.dk)                                                       | Forskelligt | ✅ | ✅ |
+| [Åbne data fra Aarhus kommune](https://www.odaa.dk)                                                       | Forskelligt | ✅ | ✅ |
+
 
 ## Pakker & logistisk
-- [Bring Developer](http://developer.bring.com)
-- [CoolRunner](https://docs.coolrunner.dk)
-- GLS
-    - [Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)
-    - [Parcel Processing](http://api.gls.dk/ws/)
-- [Pakkelabels.dk](https://api.pakkelabels.dk)
-- [PostNord Developer](https://developer.postnord.com)
-- [UPS](https://www.ups.com/content/dk/da/resources/sri/apidefinition.html)
-- [Unifaun](https://www.unifaunonline.se/rs-docs/)
-- [Webshipr](http://docs.webshipr.apiary.io)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Bring Developer](http://developer.bring.com)                                                             | JSON/XML/SOAP | ✅ | ✅❌ |
+| [CoolRunner](https://docs.coolrunner.dk)                                                                  | JSON | ✅ | ❌ |
+| [GLS Pakkeshops](http://www.gls.dk/webservices_v2/wsPakkeshop.asmx?WSD)                                   | SOAP | ✅ | ✅ |
+| [GLS Parcel Processing](http://api.gls.dk/ws/)                                                            | JSON/XML | ✅ | ❌ |
+| [Pakkelabels.dk](https://api.pakkelabels.dk)                                                              | JSON | ✅ | ❌ |
+| [PostNord Developer](https://developer.postnord.com)                                                      | JSON | ✅ | ❌ |
+| [UPS](https://www.ups.com/upsdeveloperkit?loc=da_DK)                                                      | JSON/XML/Webservice | ✅ | ❌ |
+| [Unifaun](https://www.unifaunonline.se/rs-docs/)                                                          | JSON | ✅ | ❌ |
+| [Webshipr](http://docs.webshipr.apiary.io)                                                                | JSON | ✅ | ❌ |
+
 
 ## Regnskabsprogrammer
 - [Billy](https://www.billy.dk/api)

--- a/README.md
+++ b/README.md
@@ -103,29 +103,46 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 
 ## Regnskabsprogrammer
-- [Billy](https://www.billy.dk/api)
-- [Dinero](https://api.dinero.dk/docs)
-- [e-conomic](https://www.e-conomic.dk/tillaegsmoduler/api)
-- [DynAccount](https://dynaccount.dk/funktioner/api-integration/)
-- [Uniconta](http://www.uniconta.com/da/uniconta-api/)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Billy](https://www.billy.dk/api)                                                                         | JSON | ✅ | ❌ |
+| [Dinero](https://api.dinero.dk/docs)                                                                      | JSON | ✅ | ❌ |
+| [e-conomic](https://restdocs.e-conomic.com)                                                               | JSON | ✅ | ❌ |
+| [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                           | JSON | ✅ | ❌ |
+| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                      | ? | ✅ | ❌ |
+| [Visma](https://developer.vismaonline.com/)                                                               | JSON | ✅ | ❌ |
 
 ## Reklamer
-- [eTilbudsavis](http://docs.api.etilbudsavis.dk)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [eTilbudsavis](http://docs.api.etilbudsavis.dk)                                                           | JSON | ✅ | ❌ |
+
 
 ## SMS Gateways
-- [Txty.dk](http://api.txty.dk/4/)
-- [SMS1919.dk](http://www.sms1919.dk/api/)
-- [GatewayAPI.com](https://gatewayapi.com/docs/)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Txty.dk](http://api.txty.dk/4/)                                                                          | JSON | ✅ | ❌ |
+| [SMS1919.dk](http://www.sms1919.dk/api/)                                                                  | XML | ✅ | ❌ |
+| [GatewayAPI.com](https://gatewayapi.com/docs/)                                                            | JSON/SOAP | ✅ | ❌ |
+
 
 ## Statistisk
-- DST API
-    - [Information om API](http://www.dst.dk/da/Statistik/statistikbanken/api)
-    - [Konsol](http://api.statbank.dk/console#subjects)
-- [Statistikbanken](http://www.dst.dk/da/Statistik/statistikbanken.aspx)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Danmarks Statistik](http://www.dst.dk/da/Statistik/statistikbanken/api)                                  | JSON/XML | ✅ | ✅ |
+
 
 ## Telefoni
-- [Firmafon](https://dev.firmafon.dk/)
-- [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Firmafon](https://dev.firmafon.dk/)                                                                      | JSON | ✅ | ❌ |
+| [Flexfone](https://cdn.rawgit.com/mauran/API-Danmark/e35d562/assets/flexfone.pdf)                         | JSON/XML | ✅ | ❌ |
+
 
 ## Transport
 - [DSB feeds](https://www.dsb.dk/dsb-labs/feeds)

--- a/README.md
+++ b/README.md
@@ -164,12 +164,15 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 
 ## Diverse
-- [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)
-- [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)
-- [Folketinget](http://www.ft.dk/AabneData)
-- [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)
-- [Lav Linket Kortere](http://llk.dk/api)
-- [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)
-- [Trustpilot](https://developers.trustpilot.com/)
-- [TimeLog](http://api.timelog.com/)
-- [Ordrestyring.dk](https://api.ordrestyring.dk)
+
+| API                                                                                                       | Type | Gratis | Uden login |
+| --------------------------------------------------------------------------------------------------------- |:----:| :-----:| :--------: |
+| [Berlingske Meningsmålninger](http://www.b.dk/upload/webred/bmsandbox/opinion_poll/2015/pollofpolls.xml)  | XML | ✅ | ✅ |
+| [Det Danske Filminstitut](http://www.dfi.dk/opendata.aspx)                                                | XML | ✅ | ✅ |
+| [Folketinget](http://www.ft.dk/AabneData)                                                                 | JSON/XML | ✅ | ✅ |
+| [HvemStemmerHvad](http://www.hvemstemmerhvad.dk/api/api.php) (information om politikere)                  | XML | ✅ | ✅ |
+| ~~[Lav Linket Kortere](http://llk.dk/api)~~                                                               | RAW/HTTP | ✅ | ✅ |
+| [MadOpskrifter.nu](http://start.madopskrifter.nu/MadopskrifternuAPI.aspx)                                 | JSON | ✅ | ✅ |
+| [Trustpilot](https://developers.trustpilot.com/)                                                          | JSON | ✅ | ❌ |
+| [TimeLog](http://api.timelog.com/)                                                                        | XML | ✅ | ✅ |
+| [Ordrestyring.dk](https://api.ordrestyring.dk/)                                                           | JSON | ✅ | ❌ |

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 | [UnoEuro](https://www.unoeuro.com/docs/api.php)                                                                | JSON | Private |
 
 
-## Inkasso
-
-| API                                                                                                            | Type | Tilgængelighed |
-| -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Debito](https://www.debito.dk/api)                                                                            | ? | ? |
-
 ## Medier
 
 | API                                                                                                            | Type | Tilgængelighed |
@@ -63,8 +57,8 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
-| [Ressource](http://arealinformation.miljoeportal.dk/distribution/)                                             | ? | ? |
-| ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~              | ? | ? |
+| [Ressource](http://www.miljoeportal.dk/digital/Sider/forside.aspx)                                             | Webservice | Public |
+| ~~[Datakilder](http://www.miljoeportal.dk/soegmiljoedata/soeg_areal/Sider/download%20data.aspx)~~              | Webservice | Public |
 
 
 ## Offentlige
@@ -110,7 +104,7 @@ Kender du et dansk API der mangler på listen? Så send et pull request afsted e
 | [Dinero](https://api.dinero.dk/docs)                                                                           | JSON | Private |
 | [e-conomic](https://restdocs.e-conomic.com)                                                                    | JSON | Private |
 | [DynAccount](https://dynaccount.dk/funktioner/api-integration/)                                                | JSON | Private |
-| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                           | ? | Private |
+| [Uniconta](http://www.uniconta.com/da/uniconta-api/)                                                           | .NET | Private |
 | [Visma](https://developer.vismaonline.com/)                                                                    | JSON | Private |
 
 ## Reklamer


### PR DESCRIPTION
## Ændringer ifht. #27 

+ Tabeller
+ Fix `Quickpay` link
+ Fix `Historisk Atlas` link
+ Fix `UPS` link
+ Ændrede Københavns solutionlab link da kategorien er "Åbne datasæt" og linket var til hele projektet
+ Opdaterede `e-conomic` link til at henvise til REST docs. Vi kan også henvise til deres SOAP docs. som har flere endpoints m.m. men det er deres REST som er nyest.
+ Tilføjede Visma regnskab api
+ Fjernet DST konsol fordi deres API side linker dertil med CTA.
+ Omdøbte DST => Danmarks Statistik
+ Fjernede Statistikbanken da det var samme API. Den ene var blot et UI og den anden det egentlige API
+ `Rejseplanen Labs` nyt link
+ Lav Linket Kortere er udgået (midlertidligt?)
+ Tilføjet Tilgængelighedsinfo
+ Tilføjet tilgængelighed