### PR TITLE
"Tilgængelighed" for Medier -> DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Du skal have en "relation" til firmaet der udstiller API'et, betalt eller ej.
 | API                                                                                                            | Type | Tilgængelighed |
 | -------------------------------------------------------------------------------------------------------------- |:----:| :------------: |
 | [DMI Vejr](https://confluence.govcloud.dk/display/FDAPI)                                                       | JSON | Private |
-| [DR](http://www.dr.dk/mu-online/)                                                                              | JSON | Public |
+| [DR](http://www.dr.dk/mu-online/)                                                                              | JSON | Private |
 | [TV2 Vejret API](https://vejret-api.tv2.dk) (Private API)                                                      | JSON/XML | Private |
 | [Vejret i din by](http://vejr.eu/pages/api-documentation)                                                      | JSON | Public |
 


### PR DESCRIPTION
Ser ud til denne falder under definitionen for "private" tilgængelighed. Man mødes i hvert fald med denne besked øverst på siden når man følger linket (http://www.dr.dk/mu-online/):

 "Anvendelse af API fra DR kræver tilladelse fra DR. Tilladelse gives kun efter en konkret vurdering og **kun til udviklere med mere, der udfører arbejde for DR.**

It requires explicit authorization from DR to access this API. The authorization can only be granted, if a thorough application process has granted access to developers et al. which works with/for DR. "