### PR TITLE
Set DMI Vejr to "public"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,14 @@ Du skal have en "relation" til firmaet der udstiller API'et, betalt eller ej.
 
 | API                                                       | Type | Tilgængelighed |
 |-----------------------------------------------------------|:----:|:--------------:|
-| [DMI Vejr](https://confluence.govcloud.dk/display/FDAPI)  | JSON |    Private     |
 | [DR](http://www.dr.dk/mu-online/)                         | JSON |    Private     |
+
+
+## Vejr
+
+| API                                                       | Type | Tilgængelighed |
+|-----------------------------------------------------------|:----:|:--------------:|
+| [DMI Vejr](https://confluence.govcloud.dk/display/FDAPI) - Vejr-, klima- og observationsdata | GeoJSON/JSON |     Public     |
 | [Vejret i din by](http://vejr.eu/pages/api-documentation) | JSON |     Public     |
 
 


### PR DESCRIPTION
DMI har løsnet op for adgangen til sine data, og tilføjet flere API'er, siden de blev tilføjet til denne liste:
https://www.dmi.dk/index.php?id=1231&L=0

I min optik, bør den heller ikke ligge under "Medier", så det har jeg også rettet.

